### PR TITLE
added varName to termUtilities

### DIFF
--- a/example_SetlX_code/evaluate.stlx
+++ b/example_SetlX_code/evaluate.stlx
@@ -1,0 +1,31 @@
+loadLibrary("termUtilities");
+
+// Die Prozedur eval(f, I) wertet die aussagen-logische Formel f unter
+// der aussagen-logischen Interpretation I aus.
+evaluate := procedure(f, i) {
+    match (f) {
+        case true:              return true;
+        case false:             return false;
+        case p | isVariable(p): return i[varName(p)];
+        case !g:                return !evaluate(g, i);
+        case g && h:            return  evaluate(g, i) && evaluate(h, i);
+        case g || h:            return  evaluate(g, i) || evaluate(h, i);
+        case g => h:            return  evaluate(g, i) => evaluate(h, i);
+        case g <==> h:          return  evaluate(g, i) == evaluate(h, i);
+        default:                abort("syntax error in evaluate($f$, $i$)");
+    }
+};
+
+f := parseTerm("(p => q) => (!p => q) => q");
+i := { [ "p", true ], [ "q", true ] };
+print( "evaluate($f$, $i$) = $evaluate(f, i)$" );
+i := { [ "p", true ], [ "q", false ] };
+print( "evaluate($f$, $i$) = $evaluate(f, i)$" );
+i := { [ "p", false ], [ "q", true ] };
+print( "evaluate($f$, $i$) = $evaluate(f, i)$" );
+i := { [ "p", false ], [ "q", false ] };
+print( "evaluate($f$, $i$) = $evaluate(f, i)$" );
+
+
+
+   

--- a/example_SetlX_code/evaluate.stlx.reference
+++ b/example_SetlX_code/evaluate.stlx.reference
@@ -1,0 +1,4 @@
+evaluate((p => q) => (!p => q) => q, {["p", true], ["q", true]}) = true
+evaluate((p => q) => (!p => q) => q, {["p", true], ["q", false]}) = true
+evaluate((p => q) => (!p => q) => q, {["p", false], ["q", true]}) = true
+evaluate((p => q) => (!p => q) => q, {["p", false], ["q", false]}) = true

--- a/interpreter/integrationTests/library_termUtilities.stlx
+++ b/interpreter/integrationTests/library_termUtilities.stlx
@@ -23,6 +23,14 @@ expressionLoopTest := procedure(expression) {
     afterFromTerm := fromTerm(afterToTerm);
     registerTestResult(expressionTerm == afterFromTerm, "expression loop '$expression$'");
 };
+varNameTest := procedure(name) {
+    term   := parse(name);
+    result := varName(term);
+    registerTestResult(result == name, "varName");
+};
+varNameTest("x");
+varNameTest("a_bC");
+varNameTest("Hugo");
 
 toTermTest("sin(x)", "@sin(x)");
 toTermTest("sin(x) / cos(x)", "@sin(x) / @cos(x)");

--- a/interpreter/setlXlibrary/termUtilities.stlx
+++ b/interpreter/setlXlibrary/termUtilities.stlx
@@ -33,6 +33,11 @@ parseTerm := procedure(s) {
     return toTerm(parse(s));
 };
 
+// Extract the name of a term representing a variable.
+varName := procedure(v) {
+    return args(v)[1];
+};
+
 // Take a simple term produced by the function toTerm and transform it
 // back into a term that represents the internal structure required by
 // setlX. This way it can be evaluated using evalTerm().


### PR DESCRIPTION
The function varName extracts the name of a term representing a variable.  Since I have to use it in many of my programs dealing with propositional logic, I would like the function to be included in the library termUtilities.
