### PR TITLE
Use jline to get REPL input

### DIFF
--- a/interpreter/pc_ui/pom.xml
+++ b/interpreter/pc_ui/pom.xml
@@ -18,6 +18,11 @@
             <artifactId>setlX-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+            <version>3.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/interpreter/pc_ui/src/main/java/org/randoom/setlx/pc/ui/SetlX.java
+++ b/interpreter/pc_ui/src/main/java/org/randoom/setlx/pc/ui/SetlX.java
@@ -12,6 +12,12 @@ import org.randoom.setlx.utilities.ParseSetlX;
 import org.randoom.setlx.utilities.State;
 import org.randoom.setlx.utilities.WriteFile;
 
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -231,15 +237,25 @@ public class SetlX {
     }
 
     private static void parseAndExecuteInteractive(final State state) {
+        Terminal terminal;
+        LineReader reader;
+        try {
+            terminal = TerminalBuilder.builder().system(true).build();
+            reader = LineReaderBuilder.builder().terminal(terminal).build();
+        } catch (IOException ex) {
+            state.errWriteLn(ex.getMessage());
+            return;
+        }
+
         state.setInteractive(true);
         Block   blk;
         boolean skipTest;
         do {
             try {
                 // prompt including newline to visually separate the next input
-                state.prompt("\n=> ");
+                String line = reader.readLine("\n=> ");
                 state.resetParserErrorCount();
-                blk = ParseSetlX.parseInteractive(state);
+                blk = ParseSetlX.parseStringToBlock(state, line);
                 if ( ! state.isMultiLineEnabled()) {
                     state.outWriteLn();
                 }


### PR DESCRIPTION
Arrow keys are currently broken when running the SetlX REPL from a terminal.
```
-===============================Interactive=Mode==============================-

=> hello := "a^[[D^[[D^[[A
```

[Jline](https://github.com/jline/jline3) is a library similar to GNU readline and BSD editline and allows usage of the arrow keys for navigation, both on the same line and on the input history.
This implementation definitely has a few rough edges and probably disregards some SetlX specific internals, but it's a foundation to work with.